### PR TITLE
Clean up white space in PortalRodents

### DIFF
--- a/PortalForecasts.R
+++ b/PortalForecasts.R
@@ -52,8 +52,8 @@ controls$total = rowSums(controls[,-(1:2)])
 controls = controls %>%
   filter(treatment == 'control') %>%
   select(-treatment) %>%
-  inner_join(moons,by=c("period"="Period")) %>% 
-  subset(NewMoonNumber >= historic_start_newmoon) %>% 
+  inner_join(moons,by=c("period"="Period")) %>%
+  subset(NewMoonNumber >= historic_start_newmoon) %>%
   select(-NewMoonDate,-CensusDate,-period,-Year,-Month)
 
 #All plots
@@ -61,7 +61,7 @@ all=PortalDataSummaries::abundance(level="Site",type="Rodents",length="all", inc
 #The total rodent count across the entire site
 all$total = rowSums(all[,-(1)])
 all=inner_join(moons,all,by=c("Period"="period"))
-  
+
 all=subset(all,Period >= historic_start_period)
 
 ###################################################################################
@@ -84,33 +84,33 @@ weather_data = weather_data %>%
 ##Get 6 month weather forecast by combining stations data and monthly means of past 3 years
 #Used to make predictions for the months 7-12 of a 12 month forecast using a 6 month lag.
 
-#A data.frame of the months that will be in this weather forecast. 
+#A data.frame of the months that will be in this weather forecast.
 weather_forecast_months = moons %>%
   filter(NewMoonNumber >= first_forecast_newmoon-5, NewMoonNumber <= last_forecast_newmoon-5)
-  
-#  x=subset(weather,NewMoonNumber>=first_forecast_newmoon-5) %>% 
+
+#  x=subset(weather,NewMoonNumber>=first_forecast_newmoon-5) %>%
 #  subset(NewMoonNumber<=last_forecast_newmoon-5)
 
-weathermeans=weather_data[dim(weather_data)[1]-36:dim(weather_data)[1],] %>% 
-  group_by(Month) %>% 
+weathermeans=weather_data[dim(weather_data)[1]-36:dim(weather_data)[1],] %>%
+  group_by(Month) %>%
   summarize(MinTemp=mean(MinTemp,na.rm=T),MaxTemp=mean(MaxTemp,na.rm=T),MeanTemp=mean(MeanTemp,na.rm=T),
             Precipitation=mean(Precipitation,na.rm=T),NDVI=mean(NDVI,na.rm=T)) %>%
   slice(match(weather_forecast_months$Month, Month))
 
 #Insert longterm means where there is missing data in the historic weather
 weather_data=weather_data %>%
-  mutate(NDVI = ifelse(is.na(NDVI), mean(NDVI, na.rm = T), NDVI)) %>% 
-  mutate(MinTemp = ifelse(is.na(MinTemp), mean(MinTemp, na.rm = T), MinTemp)) %>% 
-  mutate(MaxTemp = ifelse(is.na(MaxTemp), mean(MaxTemp, na.rm = T), MaxTemp)) %>% 
-  mutate(MeanTemp = ifelse(is.na(MeanTemp), mean(MeanTemp, na.rm = T), MeanTemp)) %>% 
+  mutate(NDVI = ifelse(is.na(NDVI), mean(NDVI, na.rm = T), NDVI)) %>%
+  mutate(MinTemp = ifelse(is.na(MinTemp), mean(MinTemp, na.rm = T), MinTemp)) %>%
+  mutate(MaxTemp = ifelse(is.na(MaxTemp), mean(MaxTemp, na.rm = T), MaxTemp)) %>%
+  mutate(MeanTemp = ifelse(is.na(MeanTemp), mean(MeanTemp, na.rm = T), MeanTemp)) %>%
   mutate(Precipitation = ifelse(is.na(Precipitation), mean(Precipitation, na.rm = T), Precipitation))
 
-#Get only relevent columns now that this is isn't needed to subset weather. 
+#Get only relevent columns now that this is isn't needed to subset weather.
 all=all %>%
-  select(-NewMoonDate,-CensusDate,-Period,-Year,-Month) 
+  select(-NewMoonDate,-CensusDate,-Period,-Year,-Month)
 
 #tscount::tsglm() will not model a timeseries of all 0's. So for those species, which are
-#ones that just haven't been observed in a while, make a forecast of all 0's. 
+#ones that just haven't been observed in a while, make a forecast of all 0's.
 zero_abund_forecast = list(pred=rep(0,12), interval=matrix(rep(0,24), ncol=2))
 colnames(zero_abund_forecast$interval) = c('lower','upper')
 
@@ -118,38 +118,38 @@ colnames(zero_abund_forecast$interval) = c('lower','upper')
 
 forecastall <- function(abundances, level, weather_data, weatherforecast, CI_level = 0.9, num_forecast_months = 12) {
   all_model_aic = data.frame()
-  
+
   ##Community level predictions
-  
+
   #naive models
   model01=forecast(abundances$total,h=num_forecast_months,level=CI_level,BoxCox.lambda(0),allow.multiplicative.trend=T)
-  
+
   forecasts01=data.frame(date=forecast_date, forecastmonth=forecast_months,forecastyear=forecast_years, NewMoonNumber=forecast_newmoons,
-                         currency="abundance",model="Forecast", level=level, species="total", estimate=model01$mean, 
+                         currency="abundance",model="Forecast", level=level, species="total", estimate=model01$mean,
                          LowerPI=model01$lower[,which(model01$level==CI_level*100)], UpperPI=model01$upper[,which(model01$level==CI_level*100)])
   forecasts01[sapply(forecasts01, is.ts)] <- lapply(forecasts01[sapply(forecasts01, is.ts)],unclass)
   all_model_aic = all_model_aic %>%
     bind_rows(data.frame(date=forecast_date, model='Forecast', currency='abundance', level=level, species='total', aic=model01$model$aic))
-  
+
   model02=forecast(auto.arima(abundances$total,lambda = 0),h=num_forecast_months,level=CI_level,fan=T)
-  
+
   forecasts02=data.frame(date=forecast_date, forecastmonth=forecast_months, forecastyear=forecast_years, NewMoonNumber=forecast_newmoons,
-                         currency="abundance", model="AutoArima", level=level, species="total", estimate=model02$mean, 
+                         currency="abundance", model="AutoArima", level=level, species="total", estimate=model02$mean,
                          LowerPI=model02$lower[,which(model02$level==CI_level*100)], UpperPI=model02$upper[,which(model02$level==CI_level*100)])
   forecasts02[sapply(forecasts02, is.ts)] <- lapply(forecasts02[sapply(forecasts02, is.ts)],unclass)
   all_model_aic = all_model_aic %>%
     bind_rows(data.frame(date=forecast_date, model='AutoArima', currency='abundance', level=level, species='total', aic=model02$model$aic))
-  
+
   #Start builing results table
   forecasts=rbind(forecasts01,forecasts02)
-  
+
   ##Time Series Model and Species level predictions
-  #Note: PI is missing. It has an error in the Poison Env model which produces NA values. 
+  #Note: PI is missing. It has an error in the Poison Env model which produces NA values.
   species=c('BA','DM','DO','DS','NA','OL','OT','PB','PE','PF','PH','PL','PM','PP','RF','RM','RO','SF','SH','SO','total')
-  
+
   #Model AIC sometimes doesn't work if species counts are low. In that case give a very large AIC.
   for(s in species) {
-    species_abundance = abundances %>% 
+    species_abundance = abundances %>%
       extract2(s)
 
     if(sum(species_abundance) == 0){
@@ -157,21 +157,21 @@ forecastall <- function(abundances, level, weather_data, weatherforecast, CI_lev
       model_aic = 1e6
     } else {
       model=tsglm(species_abundance,model=list(past_obs=1,past_mean=12),distr="nbinom")
-      pred=predict(model,num_forecast_months,level=CI_level) 
+      pred=predict(model,num_forecast_months,level=CI_level)
       model_aic = ifelse(has_error(summary(model)),1e6,summary(model)$AIC)
     }
-    newpred=data.frame(date=rep(forecast_date,num_forecast_months), forecastmonth=forecast_months, forecastyear=forecast_years, 
-                       NewMoonNumber=forecast_newmoons, currency="abundance", model=rep("NegBinom Time Series",num_forecast_months), 
-                       level=level, species=rep(s,num_forecast_months), estimate=pred$pred, 
+    newpred=data.frame(date=rep(forecast_date,num_forecast_months), forecastmonth=forecast_months, forecastyear=forecast_years,
+                       NewMoonNumber=forecast_newmoons, currency="abundance", model=rep("NegBinom Time Series",num_forecast_months),
+                       level=level, species=rep(s,num_forecast_months), estimate=pred$pred,
                        LowerPI=pred$interval[,1], UpperPI=pred$interval[,2])
     forecasts=rbind(forecasts,newpred)
-    
+
     all_model_aic = all_model_aic %>%
       bind_rows(data.frame(date=forecast_date, model='NegBinom Time Series', currency='abundance', level=level, species=s, aic=model_aic))
   }
-  
+
   #Species level time time series model with the best environmental covariates chosen by AIC
-  
+
   #List of candiate environmental covariate models
   model_covariates = list(c('MaxTemp','MeanTemp','Precipitation','NDVI'),
                           c('MaxTemp','MinTemp','Precipitation','NDVI'),
@@ -183,9 +183,9 @@ forecastall <- function(abundances, level, weather_data, weatherforecast, CI_lev
                           c('MeanTemp'),
                           c('Precipitation'),
                           c('NDVI'))
-  
+
   for(s in species) {
-    species_abundance = abundances %>% 
+    species_abundance = abundances %>%
       extract2(s)
 
     if(sum(species_abundance) == 0){
@@ -195,7 +195,7 @@ forecastall <- function(abundances, level, weather_data, weatherforecast, CI_lev
       best_model_aic = Inf
       best_model = NA
       for(proposed_model_covariates in model_covariates){
-        proposed_model = tsglm(species_abundance, model=list(past_obs=1,past_mean=12), distr="poisson", 
+        proposed_model = tsglm(species_abundance, model=list(past_obs=1,past_mean=12), distr="poisson",
                                xreg=weather_data[,unlist(proposed_model_covariates)], link = "log")
         #tsglm sometimes outputs an error when the time series have many 0's, in that case set the AIC
         #to Inf so this proposed model covariate set get skipped
@@ -205,9 +205,9 @@ forecastall <- function(abundances, level, weather_data, weatherforecast, CI_lev
           best_model_aic = proposed_model_aic
         }
       }
-    
+
       #If no best model was chosen, ie. they all had infinit AIC's due to errors in model building
-      #then forecast 0's. Also make an extremely high AIC so this isn't weighted heavily in the ensemble. 
+      #then forecast 0's. Also make an extremely high AIC so this isn't weighted heavily in the ensemble.
       if(is.na(best_model)){
         pred = zero_abund_forecast
         model_aic = 1e6
@@ -218,16 +218,16 @@ forecastall <- function(abundances, level, weather_data, weatherforecast, CI_lev
     }
     newpred = data.frame(date=rep(forecast_date,num_forecast_months), forecastmonth=forecast_months, forecastyear=forecast_years,
                          NewMoonNumber=forecast_newmoons, currency="abundance", model=rep("Poisson Env",num_forecast_months),
-                         level=level, species=rep(s,num_forecast_months), estimate=pred$pred, 
+                         level=level, species=rep(s,num_forecast_months), estimate=pred$pred,
                          LowerPI=pred$interval[,1],UpperPI=pred$interval[,2])
     forecasts = rbind(forecasts,newpred)
     all_model_aic = all_model_aic %>%
       bind_rows(data.frame(date=forecast_date, model='Poisson Env', currency='abundance', level=level, species=s, aic=model_aic))
   }
-  
-  write.csv(forecasts, paste(as.character(forecast_date),level,filename_suffix,".csv",sep=""),           row.names=FALSE) 
-  write.csv(all_model_aic, paste(as.character(forecast_date),level,filename_suffix,"_model_aic.csv",sep=""), row.names=FALSE) 
-  
+
+  write.csv(forecasts, paste(as.character(forecast_date),level,filename_suffix,".csv",sep=""),           row.names=FALSE)
+  write.csv(all_model_aic, paste(as.character(forecast_date),level,filename_suffix,"_model_aic.csv",sep=""), row.names=FALSE)
+
   return(forecasts)
 }
 


### PR DESCRIPTION
There is a lot of trailing white space in PortalRodents.R. RStudio
cleans this up by default meaning that avoiding messy diffs for this
file is tricky. This cleans up all of the white space in one go so that
it won't cause future issues.