### PR TITLE
Automatically archive to Zenodo

### DIFF
--- a/update_repo.sh
+++ b/update_repo.sh
@@ -1,5 +1,5 @@
-last_commit_date=`git log --author='Weecology Deploy Bot' -1 --format=%cd | head -c 10`
-current_date=`date | head -c 10`
+last_commit_date=`git log --date=iso --author='Weecology Deploy Bot' -1 --format=%cd | head -c 10`
+current_date=`date -I | head -c 10`
 if [ "$last_commit_date" !=  "$current_date" ]; then
     git config --global user.email "weecologydeploy@weecology.org"
     git config --global user.name "Weecology Deploy Bot"
@@ -10,4 +10,9 @@ if [ "$last_commit_date" !=  "$current_date" ]; then
 
     git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/portalPredictions.git > /dev/null 2>&1
     git push --quiet deploy master > /dev/null 2>&1
+
+    # Create a new release to trigger automated Zenodo archiving
+    git tag $current_date
+    git push --quiet deploy --tags > /dev/null 2>&1
+    curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_RELEASE_TOKEN" https://api.github.com/repos/weecology/portalPredictions/releases -d '{"tag_name":"$current_date"}'
 fi


### PR DESCRIPTION
This change automatically adds a new tag using the current date
and then uses the API to create a release. Since the repo is set up
to archive to Zenodo on release.

This creates a new archive of the entire code base including all of
the predictions. This isn't ideal since there's lots of other stuff
in the repo, but for the time being this is the thing I can get
working.