### PR TITLE
Stop build from failing when new packages added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 
 script:
   - docker exec -i ppred git clone https://github.com/weecology/portalPredictions.git
+  - docker exec -i ppred bash -c "cd portalPredictions && Rscript install-packages.R"
   - docker exec -i ppred bash -c "cd portalPredictions && Rscript PortalForecasts.R"
   - docker cp ppred:/portalPredictions portalPredictionsResult
   - cd portalPredictionsResult

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ Models currently in use are in the models directory. Models that were used or we
 
 Predictions contains all predictions made thusfar and model aics. Each new prediction made on a particular time series (varies by level and currency) is saved in a new file in this directory.
 
+## Docker builds
+
+Forecasts are run using Travis CI based on a docker image. This makes the builds
+faster and more reproducible. When adding new packages to this repo it may be
+necessary to update the Docker container using the following commands:
+
+```
+sudo docker build -t weecology/portal_predictions .
+sudo docker push weecology/portal_predictions
+```


### PR DESCRIPTION
Update packages inside the docker build to make sure that new packages that are
not yet in the docker image are available.

Also add instructions for building and pushing the docker image.