### PR TITLE
Don't build if the last commit is from the deploy bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: bash
 sudo: required
+if: sender != ^weecologydeploy$
 
 before_install:
   - docker pull weecology/portal_predictions


### PR DESCRIPTION
We are currently building cron triggered builds twice. The first time is when
cron triggers the build. This build updates the repository for archiving
purposes. That then triggers a second build.

It is unclear if this will work because the `sender` variable is completely
undocumented as far as I can tell. It is unclear if it refers to the repository
owner or the committer and also unclear what form it should take.

If this works it would take care of #137.