### PR TITLE
Show the actual Travis build number not variable name in commit

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
     # Commit changes to portalPredictions repo
     git checkout master
     git add predictions/* docs/* data/*
-    git commit -m 'Update forecasts: Travis Build $TRAVIS_BUILD_NUMBER [ci skip]'
+    git commit -m "Update forecasts: Travis Build $TRAVIS_BUILD_NUMBER [ci skip]"
 
     git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/portalPredictions.git > /dev/null 2>&1
     git push --quiet deploy master > /dev/null 2>&1


### PR DESCRIPTION
In 8138d2b6b223b9aa5ffc81509f5f1ed4cb0106a7 the quotation marks were changed
from double to single. This changes how the reference to environmental
variables gets handled and results in showing $TRAVIS_BUILD_NUMBER instead
of the actual value.

Fixes #190.