### PR TITLE
Fix external archiving by knowing where you are

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -26,9 +26,9 @@ if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
     curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_RELEASE_TOKEN" https://api.github.com/repos/weecology/portalPredictions/releases -d "{\"tag_name\":\"$current_date\"}"
 
     # Clone forecasts archive repo
-    cd ../
+    cd ../../
     git clone https://github.com/weecology/forecasts
-    cp portalPredictions/predictions/*.* forecasts/portal/
+    cp portalPredictions/portalPredictionsResult/predictions/*.* forecasts/portal/
     cd forecasts
 
     # Commit to forecasts repo


### PR DESCRIPTION
External archiving wasn't working because the script was looking in the wrong
place for the files to archive and therefore not copying any files and not
having anything to commit. The paths are a little tricky due to copying in and
out of the docker image.