### PR TITLE
Add Zenodo JSON file to properly list authors in archive

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,42 @@
+{
+  "creators": [
+    {
+      "affiliation": "University of Florida",
+      "name": "Ethan P. White",
+      "orcid": "0000-0001-6728-7745"
+    },
+    {
+      "affiliation": "University of Florida",
+      "name": "Glenda M. Yenni",
+      "orcid": "0000-0001-6969-1848"
+    },
+    {
+      "affiliation": "University of Florida",
+      "name": "Shawn D. Taylor",
+      "orcid": "0000-0002-6178-6903"
+    },
+    {
+      "affiliation": "University of Florida",
+      "name": "Erica M. Christensen",
+      "orcid": "0000-0002-5635-2502"
+    },
+    {
+      "affiliation": "University of Florida",
+      "name": "Ellen K. Bledsoe",
+      "orcid": "0000-0002-3629-7235"
+    },
+      {
+      "affiliation": "University of Florida",
+      "name": "S. K. Morgan Ernest",
+      "orcid": "0000-0002-6026-8530"
+    }
+  ],
+  "keywords": [
+    "ecology",
+    "forecasting",
+    "pipeline",
+    "continuous analysis"
+  ],
+  "license": "cc-zero",
+  "upload_type": "dataset"
+}


### PR DESCRIPTION
This will make Zenodo list authors and affiliations in the way we want them.