### PR TITLE
Correctly state that prediction intervals are 90% in evaluation

### DIFF
--- a/data/model_metadata.yaml
+++ b/data/model_metadata.yaml
@@ -1,5 +1,6 @@
 filename_suffix: forecasts
 forecast_date: '2018-02-16'
+pred_interval: 0.9
 forecast_newmoons:
 - 503
 - 504

--- a/evaluation.Rmd
+++ b/evaluation.Rmd
@@ -10,8 +10,11 @@ knitr::opts_chunk$set(
 )
 library(dplyr)
 library(portalr)
+library(yaml)
 source("tools/forecast_tools.R")
 
+model_metadata = yaml.load_file("data/model_metadata.yaml")
+pred_interval = model_metadata$pred_interval
 models_of_interest = c('AutoArima','Ensemble','ESSS','nbGARCH','pevGARCH')
 
 species_of_interest = c('BA','DM','DO','PP','OT','NA','total')
@@ -167,7 +170,7 @@ ggplot(forecast_errors, aes(x=censusdate, y=rmse, group=as.character(date), colo
 These graphs show errors as a function of lead time. The lead time is the number of months into the future that forecast is made. The error values are an average of all forecast errors using observations since 2010. Note that this currently uses hindcasts of the prior observations, and is also only for the Control plots.
 
 **RMSE**: Root mean square error, this is a metric used to evaluate the point estimate of a forecast.  
-**Coverage**: This is the percentage of observations which fell within the 95% confidence interval of a forecast. Ideally this would be equal to 0.95. If it's higher than 0.95 the forecasts intervals are too wide, if it's lower then the forecast intervals are too narrow.
+**Coverage**: This is the percentage of observations which fell within the `r 100 * pred_interval`% confidence interval of a forecast. Ideally this would be equal to `r pred_interval`. If it's higher than `r pred_interval` the forecasts intervals are too wide, if it's lower then the forecast intervals are too narrow.
 
 
 ```{r hindcast_eval, echo=FALSE, message=FALSE, warning=FALSE,, fig.width=9, fig.height=15}
@@ -184,7 +187,7 @@ forecast_errors = forecast_errors %>%
 ggplot(forecast_errors, aes(x=lead_time, y=error_value, group=model, color=model)) +
   geom_point()+
   geom_line() +
-  geom_hline(yintercept = 0.95) +
+  geom_hline(yintercept = 0.9) +
   labs(x='Lead Time (New Moons)') +
   facet_wrap(full_species_name~error_metric, scales = 'free_y', ncol=2) + 
   theme_bw() +


### PR DESCRIPTION
The prediction intervals have always been 90%, but they were described and shown
as 95%. This fixes this issue and in the process creates a new metadata value
for the prediction interval (thanks to @ha0ye's suggestion) that can be used
throughout the code base. Updates to the models will be necessary to use this
value for all instances of prediction interval in the code base.