### PR TITLE
debugging the location of files under portalcasting

### DIFF
--- a/PortalForecasts.R
+++ b/PortalForecasts.R
@@ -1,11 +1,11 @@
 library(portalcasting)
 
 #Update data and models
-setup_dir(options_all = all_options(main = "portalPredictions", download_existing_predictions = FALSE))
+setup_dir(options_all = all_options(main = "", download_existing_predictions = FALSE))
 
 #Run all models using portalcasting defaults
 
-portalcast(options_all = all_options(main = "portalPredictions"))
+portalcast(options_all = all_options(main = ""))
 message("models done")
 
 #Update Website

--- a/PortalForecasts.R
+++ b/PortalForecasts.R
@@ -1,13 +1,13 @@
 library(portalcasting)
 
 #Update data and models
-setup_dir(options_all = all_options(base = ".", main = "", download_existing_predictions = FALSE))
-unlink(sub_paths(dirtree(base = ".", main = "", subs = "PortalData")), recursive = TRUE, force = TRUE)
+setup_dir()
 
 #Run all models using portalcasting defaults
-
-portalcast(options_all = all_options(base = ".", main = ""))
-message("models done")
+portalcast()
 
 #Update Website
 rmarkdown::render_site()
+
+#Clean up temporary files
+cleanup_dir()

--- a/PortalForecasts.R
+++ b/PortalForecasts.R
@@ -1,11 +1,12 @@
 library(portalcasting)
 
 #Update data and models
-setup_dir(options_all = all_options(main = "", download_existing_predictions = FALSE))
+setup_dir(options_all = all_options(base = ".", main = "", download_existing_predictions = FALSE))
+unlink(sub_paths(dirtree(base = ".", main = "", subs = "PortalData")), recursive = TRUE, force = TRUE)
 
 #Run all models using portalcasting defaults
 
-portalcast(options_all = all_options(main = ""))
+portalcast(options_all = all_options(base = ".", main = ""))
 message("models done")
 
 #Update Website

--- a/install-packages.R
+++ b/install-packages.R
@@ -8,4 +8,5 @@ if ("pacman" %in% rownames(installed.packages()) == FALSE) install.packages("pac
 pacman::p_load(devtools, dplyr, forecast, ggplot2, htmltab, lubridate, ltsa, magrittr, 
                parallel, RCurl, readr, rmarkdown, testthat, tidyverse, tscount, yaml, zoo)
 pacman::p_load_gh('weecology/portalr')
-pacman::p_load_gh('weecology/portalcasting')
+#pacman::p_load_gh('weecology/portalcasting')
+devtools::install_github("weecology/portalcasting")

--- a/install-packages.R
+++ b/install-packages.R
@@ -8,5 +8,4 @@ if ("pacman" %in% rownames(installed.packages()) == FALSE) install.packages("pac
 pacman::p_load(devtools, dplyr, forecast, ggplot2, htmltab, lubridate, ltsa, magrittr, 
                parallel, RCurl, readr, rmarkdown, testthat, tidyverse, tscount, yaml, zoo)
 pacman::p_load_gh('weecology/portalr')
-#pacman::p_load_gh('weecology/portalcasting')
-devtools::install_github("weecology/portalcasting")
+pacman::p_load_gh('weecology/portalcasting')


### PR DESCRIPTION
the first implementation of portalcasting (c083f1ffadc60e9b846ec86951241d8c1e34cf3d) was successful in that the models ran just fine, but unsuccessful in that they ran somewhere else. 
this was because we had the settings for portalcasting pointing to `~/portalPredictions` (`root/portalPredictions`), which apparently isn't the same as "the present directory" (i.e. `weecology/portalPredictions`). now we instead use "the present directory" (`.`), which should work well with the folder set up on github. 
the portalcasting package has been updated to include this as the directory default, so no inputs of specific arguments are required. the portalcasting package has also been set up to have default be `download_existing_predictions =  FALSE`, so no arguments are needed at all in the functions calls in the forecasting script.

a new function to cleanup the directory (remove the temporary folders) has been added to portalcasting and is called here now (with defaults set to work with portalPredictions)