### PR TITLE
Refactor archive.sh to run tests on PRs

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -5,42 +5,77 @@
 # Only releases on cron driven events so that only weekly forecasts and not
 # simple changes to the codebase triggers archiving.
 
+# Setup on weecologydeploy user
+git config --global user.email "weecologydeploy@weecology.org"
+git config --global user.name "Weecology Deploy Bot"
+
+# Commit changes to portalPredictions repo
+git checkout master
+git add predictions/* docs/* data/* 
+git commit -m "Update forecasts: Travis Build $TRAVIS_BUILD_NUMBER [ci skip]"
+
+# Add deploy remote
+# Needed to grant permissions through the deploy token
+git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/portalPredictions.git > /dev/null 2>&1
+
+# Create a new portalPredictions tag for release
+current_date=`date -I | head -c 10`
+git tag $current_date
+
+# If this is a cron event deploy, otherwise just check if we can
 if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 
-    # Setup on weecologydeploy user
-    git config --global user.email "weecologydeploy@weecology.org"
-    git config --global user.name "Weecology Deploy Bot"
-
-    # Commit changes to portalPredictions repo
-    git checkout master
-    git add predictions/* docs/* data/* 
-    git commit -m "Update forecasts: Travis Build $TRAVIS_BUILD_NUMBER [ci skip]"
-
-    git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/portalPredictions.git > /dev/null 2>&1
+    # Push updates to upstream
     git push --quiet deploy master > /dev/null 2>&1
 
     # Create a new portalPredictions release to trigger Zenodo archiving
-    current_date=`date -I | head -c 10`
-    git tag $current_date
     git push --quiet deploy --tags > /dev/null 2>&1
     curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_RELEASE_TOKEN" https://api.github.com/repos/weecology/portalPredictions/releases -d "{\"tag_name\":\"$current_date\"}"
 
-    # Clone forecasts archive repo
-    cd ../../
-    git clone https://github.com/weecology/forecasts
-    cp portalPredictions/portalPredictionsResult/predictions/*.* forecasts/portal/
-    cd forecasts
+else
 
-    # Commit to forecasts repo
-    git add .
-    git commit -m "Update Portal forecasts: Build $TRAVIS_BUILD_NUMBER"
-    git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/forecasts.git > /dev/null 2>&1
+    # These tests will not display output if failing (for security reasons) but will return 1
+
+    # Test pushing updates to upstream
+    git push --dry-run --quiet deploy master > /dev/null 2>&1
+
+    # Testing creating a new portalPredictions release to trigger Zenodo archiving
+    git push --dry-run --quiet deploy --tags > /dev/null 2>&1
+
+fi
+
+# Clone forecasts archive repo
+cd ../../
+git clone https://github.com/weecology/forecasts
+cp portalPredictions/portalPredictionsResult/predictions/*.* forecasts/portal/
+cd forecasts
+
+# Commit to forecasts repo
+git add .
+git commit -m "Update Portal forecasts: Build $TRAVIS_BUILD_NUMBER"
+git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/forecasts.git > /dev/null 2>&1
+
+# Create a new forecasts tag
+current_date=`date -I | head -c 10`
+git tag $current_date
+
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+
+    # Push updates to forecasts archive repo
     git push --quiet deploy master > /dev/null 2>&1
 
     # Create a new forecasts release to trigger Zenodo archiving
-    current_date=`date -I | head -c 10`
-    git tag $current_date
     git push --quiet deploy --tags > /dev/null 2>&1
     curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/weecology/forecasts/releases -d "{\"tag_name\":\"$current_date\"}"
+
+else
+
+    # These tests will not display output if failing (for security reasons) but will return 1
+
+    # Test pushing updates to forecasts archive repo
+    git push --dry-run --quiet deploy master > /dev/null 2>&1
+
+    # Test creating a new forecasts release to trigger Zenodo archiving
+    git push --dry-run --quiet deploy --tags > /dev/null 2>&1
 
 fi


### PR DESCRIPTION
1. Pulls the non-pushing code out of the cron conditional
2. Converts cron conditional into if/else and does --dry-runs for
   pushes if not the cron job

This does not currently test the API release because there will be no tag
so it is unclear how we would test that step.

Addresses issue with testing cron runs raised in #298.