### PR TITLE
Testing updates to portalcasting and portalr packages

### DIFF
--- a/install-packages.R
+++ b/install-packages.R
@@ -10,5 +10,8 @@ if ("pacman" %in% rownames(installed.packages()) == FALSE){
 pacman::p_load(devtools, dplyr, forecast, ggplot2, htmltab, lubridate, ltsa, 
                magrittr, parallel, RCurl, readr, rmarkdown, testthat, tidyverse,
                tscount, yaml, zoo)
-pacman::p_load_gh('weecology/portalr')
-pacman::p_load_gh('weecology/portalcasting')
+#pacman::p_load_gh('weecology/portalr')
+#pacman::p_load_gh('weecology/portalcasting')
+devtools::install_github("weecology/portalr", "check-github-minimally")
+devtools::install_github("weecology/portalcasting", "options_PortalData")
+

--- a/install-packages.R
+++ b/install-packages.R
@@ -12,6 +12,6 @@ pacman::p_load(devtools, dplyr, forecast, ggplot2, htmltab, lubridate, ltsa,
                tscount, yaml, zoo)
 #pacman::p_load_gh('weecology/portalr')
 #pacman::p_load_gh('weecology/portalcasting')
-devtools::install_github("weecology/portalr", "check-github-minimally")
 devtools::install_github("weecology/portalcasting", "options_PortalData")
+devtools::install_github("weecology/portalr", "check-github-minimally")
 


### PR DESCRIPTION
this PR is for verifying that the updated portalr and portalcasting packages work in the portalPredictions pipeline without having to update the docker image yet.

the portalcasting build is set to the options_PortalData branch and the portalr build is set to the check-github-minimally branch