### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 
 script:
   - docker exec -i ppred bash -c "cd portalPredictions && Rscript install-packages.R"
-  - docker exec -i ppred bash -c "cd portalPredictions && Rscript PortalForecasts.R"
-  - docker exec -i ppred bash -c "cd portalPredictions && Rscript tests/testthat.R"
+  - docker exec --env GITHUB_PAT=$GITHUB_PAT -i ppred bash -c "cd portalPredictions && Rscript PortalForecasts.R"
+  - docker exec --env GITHUB_PAT=$GITHUB_PAT -i ppred bash -c "cd portalPredictions && Rscript tests/testthat.R"
 
 after_success:
   - docker cp ppred:/portalPredictions portalPredictionsResult


### PR DESCRIPTION
pass the GITHUB_PAT token through to docker adding --env flags to the docker exec calls to run PortalForecasts and tests

note: this is now a back-up for in the cases when we need to use from_zenodo=FALSE in the retrieval of PortalData