### PR TITLE
Add ability to make weekly forecasts using HiperGator

### DIFF
--- a/archive_hipergator.sh
+++ b/archive_hipergator.sh
@@ -1,0 +1,81 @@
+# Archive forecasts by pushing weekly forecasts to GitHub and tagging a
+# release so that the GitHub-Zenodo integration archives the forecasts to
+# Zenodo
+
+# Only releases on cron driven events so that only weekly forecasts and not
+# simple changes to the codebase triggers archiving.
+
+# Setup on weecologydeploy user
+git config --global user.email "weecologydeploy@weecology.org"
+git config --global user.name "Weecology Deploy Bot"
+
+# Commit changes to portalPredictions repo
+git checkout master
+git add predictions/* docs/* data/* models/*
+git commit -m "Update forecasts: Travis Build $TRAVIS_BUILD_NUMBER [ci skip]"
+
+# Add deploy remote
+# Needed to grant permissions through the deploy token
+git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/portalPredictions.git > /dev/null 2>&1
+
+# Create a new portalPredictions tag for release
+current_date=`date -I | head -c 10`
+git tag $current_date
+
+# If this is a cron event deploy, otherwise just check if we can
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+
+    # Push updates to upstream
+    git push --quiet deploy master > /dev/null 2>&1
+
+    # Create a new portalPredictions release to trigger Zenodo archiving
+    git push --quiet deploy --tags > /dev/null 2>&1
+    curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_RELEASE_TOKEN" https://api.github.com/repos/weecology/portalPredictions/releases -d "{\"tag_name\":\"$current_date\"}"
+
+else
+
+    # These tests will not display output if failing (for security reasons) but will return 1
+
+    # Test pushing updates to upstream
+    git push --dry-run --quiet deploy master > /dev/null 2>&1
+
+    # Testing creating a new portalPredictions release to trigger Zenodo archiving
+    git push --dry-run --quiet deploy --tags > /dev/null 2>&1
+
+fi
+
+# Clone forecasts archive repo
+cd ../
+git clone https://github.com/weecology/forecasts
+cp portalPredictions/predictions/*.* forecasts/portal/
+cd forecasts
+
+# Commit to forecasts repo
+git add .
+git commit -m "Update Portal forecasts: Build $TRAVIS_BUILD_NUMBER"
+git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/forecasts.git > /dev/null 2>&1
+
+# Create a new forecasts tag
+current_date=`date -I | head -c 10`
+git tag $current_date
+
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+
+    # Push updates to forecasts archive repo
+    git push --quiet deploy master > /dev/null 2>&1
+
+    # Create a new forecasts release to trigger Zenodo archiving
+    git push --quiet deploy --tags > /dev/null 2>&1
+    curl -v -i -X POST -H "Content-Type:application/json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/weecology/forecasts/releases -d "{\"tag_name\":\"$current_date\"}"
+
+else
+
+    # These tests will not display output if failing (for security reasons) but will return 1
+
+    # Test pushing updates to forecasts archive repo
+    git push --dry-run --quiet deploy master > /dev/null 2>&1
+
+    # Test creating a new forecasts release to trigger Zenodo archiving
+    git push --dry-run --quiet deploy --tags > /dev/null 2>&1
+
+fi

--- a/cronjob.txt
+++ b/cronjob.txt
@@ -1,0 +1,18 @@
+# Cron job for weekly runs on the HiPerGator
+# This is currently running under ethanwhite's account on daemon2
+# To recreate copy, paste, and modify this text into the editor resulting
+# from `crontab -e`
+# WEECOLOGYDEPLOYGITHUBPAT needs to be replaced with the appropriate GITHUB
+# Personal Access Token
+
+# cron jobs on HiPerGator run from a blank environment so we need to set both
+# basic environmental variables (HOME and PATH) and also the GitHub tokens
+# because they are not loaded into the cronjob environment
+
+HOME=/home/ethanwhite
+PATH=/opt/slurm/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/home/ethanwhite/bin
+MAILTO=ethanwhite@ufl.edu
+GITHUB_TOKEN="WEECOLOGYDEPLOYGITHUBPAT"
+GITHUB_RELEASE_TOKEN="WEECOLOGYDEPLOYGITHUBPAT"
+TRAVIS_EVENT_TYPE="cron"
+16 14 * * * sbatch ${HOME}/portal_weekly_forecast.sh >> ${HOME}/cron.log 2>&1

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=portal_weekly_forecast
+#SBATCH --mail-user=ethanwhite@ufl.edu
+#SBATCH --mail-type=FAIL,END
+#SBATCH --ntasks=1
+#SBATCH --mem=2gb
+#SBATCH --time=3:00:00
+#SBATCH --partition=hpg2-compute
+#SBATCH --output=portal_weekly_forecast_log.out
+date;hostname;pwd
+
+source /etc/profile.d/modules.sh
+
+module load git R singularity
+
+rm -f portal_predictions_latest.sif
+rm -rf portalPredictions
+rm -rf forecasts
+singularity pull docker://weecology/portal_predictions
+git clone https://github.com/weecology/portalPredictions.git
+cd portalPredictions
+singularity run ../portal_predictions_latest.sif Rscript install-packages.R
+singularity run ../portal_predictions_latest.sif Rscript PortalForecasts.R
+singularity run ../portal_predictions_latest.sif bash archive_hipergator.sh


### PR DESCRIPTION
Run times were getting long so this PR allows running on the UF HPC.
`portal_weekly_forecast.sh` needs to be (and has been) copied into
the users home directory and the text in crontab.txt added
to a cronjob on daemon2.