### PR TITLE
Temp reversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 
 before_install:
   - docker pull weecology/portal_predictions:2019-03-21
-  - docker run --name ppred -t -d weecology/portal_predictions /bin/bash
+  - docker run --name ppred -t -d weecology/portal_predictions:2019-03-21 /bin/bash
   - docker cp ../portalPredictions ppred:/
   - docker exec -i ppred ls portalPredictions
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 sudo: required
 
 before_install:
-  - docker pull weecology/portal_predictions
+  - docker pull weecology/portal_predictions:2019-03-21
   - docker run --name ppred -t -d weecology/portal_predictions /bin/bash
   - docker cp ../portalPredictions ppred:/
   - docker exec -i ppred ls portalPredictions


### PR DESCRIPTION
given the issues with implementation of the updated portalcasting in the wild on travis (it takes too long), i've set the docker image that's pulled and used here back to the last stable one, from 2019-03-21