### PR TITLE
Fix tests for HiPerGator

### DIFF
--- a/tests/testthat/test-successful_forecasts.R
+++ b/tests/testthat/test-successful_forecasts.R
@@ -3,21 +3,21 @@ library(testthat)
 context("checks that a production pipeline has been setup and run correctly")
 
 test_that("folders exist as needed",{
-  fnames <- list.files("../../")
-  expect_equal(c("casts", "data", "models", "raw", "tmp" ) %in% fnames, TRUE)
+  fnames <- list.files()
+  expect_equal(all(c("casts", "data", "models", "raw", "tmp", "fits") %in% fnames), TRUE)
 })
 
 test_that("dir_config is present",{
-  fnames <- list.files("../../")
+  fnames <- list.files()
   expect_equal("dir_config.yaml" %in% fnames, TRUE)
 })
 
 test_that("cast_metadata file", {
-  expect_is(read_cast_metadata("../../"), "list")
+  expect_is(read_cast_metadata(), "list")
 })
 
 test_that("new casts have been made", {
-  expect_true(Sys.Date() == as.Date(read_metadata("../../")$cast_date))
+  expect_true(Sys.Date() == as.Date(read_metadata()$cast_date))
 })
 
 


### PR DESCRIPTION
Fixes errors that I'm guessing result from behavior changes in testthat:

1. Treat path for file checks as root not test directory.
2. Check to see if all directories are present. Previous code actually
   only checked casts and now triggers error.
3. Add `fits` to required directories.