### PR TITLE
Update code and docs to match shift to `main` for main branch

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -10,9 +10,9 @@ name: R
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Portal Predictions
-[![Build Status](https://travis-ci.com/weecology/portalPredictions.svg?branch=master)](https://travis-ci.com/github/weecology/portalPredictions)
+[![Build Status](https://travis-ci.com/weecology/portalPredictions.svg?branch=main)](https://travis-ci.com/github/weecology/portalPredictions)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.833438.svg)](https://doi.org/10.5281/zenodo.833438)
-[![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/weecology/portalPredictions/master/LICENSE)
+[![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/weecology/portalPredictions/main/LICENSE)
 [![NSF-1929730](https://img.shields.io/badge/NSF-1929730-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1929730)
 
 #### [Portal Forecasting Website](http://portal.naturecast.org/)
@@ -16,7 +16,7 @@ Modeling is driven by the [portalcasting package](https://github.com/weecology/p
 
 ## Docker builds
 
-Forecasts are run using [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) based on a [docker](https://hub.docker.com/) image. This makes the builds faster and more reproducible. The image is built using the [Dockerfile](https://github.com/weecology/portalPredictions/blob/master/Dockerfile), with [v0.17.1](https://github.com/weecology/portalcasting/releases/tag/v0.17.1) of `portalcasting`.
+Forecasts are run using [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) based on a [docker](https://hub.docker.com/) image. This makes the builds faster and more reproducible. The image is built using the [Dockerfile](https://github.com/weecology/portalPredictions/blob/main/Dockerfile), with [v0.17.1](https://github.com/weecology/portalcasting/releases/tag/v0.17.1) of `portalcasting`.
 
 Rebuilding of the Docker container is required to pass updates to `portalcasting` along to the executed code in the Portal Predictions pipeline. When building the image, give it two tags: `latest` and the date (as yyyy-mm-dd) using the following commands (with the actual date input):
 

--- a/archive_hipergator.sh
+++ b/archive_hipergator.sh
@@ -12,7 +12,7 @@ git config --global user.email "weecologydeploy@weecology.org"
 git config --global user.name "Weecology Deploy Bot"
 
 # Commit changes to portalPredictions repo
-git checkout master
+git checkout main
 git add data/* models/* casts/*
 git commit -m "Update forecasts: HiperGator Build $current_date [ci skip]"
 
@@ -26,7 +26,7 @@ git tag $current_date
 # If this is a cron event deploy, otherwise just check if we can
 
 # Push updates to upstream
-git push --quiet deploy master > /dev/null 2>&1
+git push --quiet deploy main > /dev/null 2>&1
 
 # Create a new portalPredictions release to trigger Zenodo archiving
 git push --quiet deploy --tags > /dev/null 2>&1
@@ -49,7 +49,7 @@ git remote add deploy https://${GITHUB_TOKEN}@github.com/weecology/forecasts.git
 git tag $current_date
 
 # Push updates to forecasts archive repo
-git push --quiet deploy master > /dev/null 2>&1
+git push --quiet deploy main > /dev/null 2>&1
 
 # Create a new forecasts release to trigger Zenodo archiving
 git push --quiet deploy --tags > /dev/null 2>&1

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -20,12 +20,12 @@ singularity pull --force docker://weecology/portal_predictions
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating forecasts repository"
 cd forecasts
 git fetch origin
-git reset --hard origin/master
+git reset --hard origin/main
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating portalPredictions repository"
 cd ../portalPredictions
 git fetch origin
-git reset --hard origin/master
+git reset --hard origin/main
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
 singularity run ../portal_predictions_latest.sif Rscript PortalForecasts.R

--- a/running_on_hipergator.md
+++ b/running_on_hipergator.md
@@ -31,7 +31,7 @@ To set this up follow these steps:
 2. Change this copy of `portal_predictions_weekly.sh` to use the users email
    address and clone the `portalPredictions` repository from the users fork.
 3. Change `archive_hipergator.sh` to push to the users fork. Optionally this
-   change could push to a branch in the users fork instead of `master` and remove everything below line 47 (the code for archiving to `weecology/forecasts`).
+   change could push to a branch in the users fork instead of `main` and remove everything below line 47 (the code for archiving to `weecology/forecasts`).
 4. `ssh` from `hpg2` into the `daemon2` server.
 5. Create a cronjob by running `crontab -e` and pasting the contents of
    `crontab.txt` into the resulting editor and replacing

--- a/tests/testthat/test-forecasts_committed.R
+++ b/tests/testthat/test-forecasts_committed.R
@@ -2,7 +2,7 @@ library(testthat)
 
 context("checks that github repository is updated correctly")
 
-# test that the remote github master branch has the newest forecasts
+# test that the remote github main branch has the newest forecasts
 new_commit <- git2r::last_commit()
 
 test_that("placeholder", {


### PR DESCRIPTION
Note that the main branch in the `weecology/forecasts` repo has also been updated hence the associated change.