### PR TITLE
Use portalcasting docker container

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: docker://weecology/portal_predictions:latest
+      image: docker://weecology/portalcasting:latest
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/README.md
+++ b/README.md
@@ -16,13 +16,4 @@ Modeling is driven by the [portalcasting package](https://github.com/weecology/p
 
 ## Docker builds
 
-Forecasts are run using [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) based on a [docker](https://hub.docker.com/) image. This makes the builds faster and more reproducible. The image is built using the [Dockerfile](https://github.com/weecology/portalPredictions/blob/main/Dockerfile), with [v0.17.1](https://github.com/weecology/portalcasting/releases/tag/v0.17.1) of `portalcasting`.
-
-Rebuilding of the Docker container is required to pass updates to `portalcasting` along to the executed code in the Portal Predictions pipeline. When building the image, give it two tags: `latest` and the date (as yyyy-mm-dd) using the following commands (with the actual date input):
-
-```
-sudo docker build -t weecology/portal_predictions:latest -t weecology/portal_predictions:yyyy-mm-dd . 
-sudo docker push weecology/portal_predictions
-```
-
-(Windows users will not need to include the `sudo` command.) 
+Forecasts are run using [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) based on a [docker](https://hub.docker.com/) image. This makes the builds faster and more reproducible. The code in this repo uses the [latest portalcasting image](https://hub.docker.com/repository/docker/weecology/portalcasting)

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -15,7 +15,7 @@ source /etc/profile.d/modules.sh
 module load git R singularity
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating singularlity container"
-singularity pull --force docker://weecology/portal_predictions
+singularity pull --force docker://weecology/portalcasting
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating forecasts repository"
 cd forecasts
@@ -28,14 +28,14 @@ git fetch origin
 git reset --hard origin/main
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
-singularity run ../portal_predictions_latest.sif Rscript PortalForecasts.R
+singularity run ../portalcasting_latest.sif Rscript PortalForecasts.R
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if forecasts were successful"
 # Redirect stderr(2) to stdout(1) if command fails, and exit script with 1
-singularity run ../portal_predictions_latest.sif Rscript tests/testthat/test-successful_forecasts.R > ../testthat.log 2>&1 || exit 1
+singularity run ../portalcasting_latest.sif Rscript tests/testthat/test-successful_forecasts.R > ../testthat.log 2>&1 || exit 1
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Archiving to GitHub and Zenodo"
-singularity run ../portal_predictions_latest.sif bash archive_hipergator.sh
+singularity run ../portalcasting_latest.sif bash archive_hipergator.sh
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if archiving to GitHub was successful"
-singularity run ../portal_predictions_latest.sif Rscript tests/testthat/test-forecasts_committed.R > ../testthat.log 2>&1 || exit 1
+singularity run ../portalcasting_latest.sif Rscript tests/testthat/test-forecasts_committed.R > ../testthat.log 2>&1 || exit 1

--- a/running_on_hipergator.md
+++ b/running_on_hipergator.md
@@ -10,7 +10,7 @@ This should only be setup by one user at a time. Currently this is Ethan White.
 
 To set this up follow these steps:
 
-1. Copy `portal_predictions_weekly.sh` into the home directory of the user under
+1. Copy `portalcasting_weekly.sh` into the home directory of the user under
    which the job will run.
 2. `ssh` from `hpg2` into the `daemon2` server.
 3. Create a cronjob by running `crontab -e` and pasting the contents of
@@ -26,9 +26,9 @@ get archived as official forecasts.
 
 To set this up follow these steps:
 
-1. Copy `portal_predictions_weekly.sh` into the home directory of the user under
+1. Copy `portalcasting_weekly.sh` into the home directory of the user under
    which the job will run.
-2. Change this copy of `portal_predictions_weekly.sh` to use the users email
+2. Change this copy of `portalcasting_weekly.sh` to use the users email
    address and clone the `portalPredictions` repository from the users fork.
 3. Change `archive_hipergator.sh` to push to the users fork. Optionally this
    change could push to a branch in the users fork instead of `main` and remove everything below line 47 (the code for archiving to `weecology/forecasts`).


### PR DESCRIPTION
We have been actively updating the portalcasting docker container,
but not the portal_predictions container. This switchers over to
using the container associated with the packaged to avoid a manual
step.