### PR TITLE
Avoid tags getting out of sync between HiPerGator and repo

### DIFF
--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -19,12 +19,12 @@ singularity pull --force docker://weecology/portalcasting
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating forecasts repository"
 cd forecasts
-git fetch origin
+git fetch origin --prune --tags
 git reset --hard origin/main
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating portalPredictions repository"
 cd ../portalPredictions
-git fetch origin
+git fetch origin --prune --tags
 git reset --hard origin/main
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"


### PR DESCRIPTION
Occasionally when the automated build breaks the tags get out of sync which then
has to be cleaned up manually. This change syncs tags as part of the initialization
of each repo before forecasting.