### PR TITLE
Delete and reclone repositories to avoid state issues

### DIFF
--- a/portal_dryrun_forecast.sh
+++ b/portal_dryrun_forecast.sh
@@ -18,14 +18,13 @@ echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating singularlity container"
 singularity pull --force docker://weecology/portalcasting
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating forecasts repository"
-cd forecasts
-git fetch origin --prune --tags
-git reset --hard origin/main
+rm -rf forecasts
+git clone https://github.com/weecology/forecasts.git
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating portalPredictions repository"
-cd ../portalPredictions
-git fetch origin --prune --tags
-git reset --hard origin/main
+rm -rf portalPredictions
+git clone https://github.com/weecology/portalPredictions.git
+cd portalPredictions
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
 singularity run ../portalcasting_latest.sif Rscript PortalForecasts.R

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -18,14 +18,13 @@ echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating singularlity container"
 singularity pull --force docker://weecology/portalcasting
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating forecasts repository"
-cd forecasts
-git fetch origin --prune --tags
-git reset --hard origin/main
+rm -rf forecasts
+git clone https://github.com/weecology/forecasts.git
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating portalPredictions repository"
-cd ../portalPredictions
-git fetch origin --prune --tags
-git reset --hard origin/main
+rm -rf portalPredictions
+git clone https://github.com/weecology/portalPredictions.git
+cd portalPredictions
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
 singularity run ../portalcasting_latest.sif Rscript PortalForecasts.R


### PR DESCRIPTION
We switched to fetching and hard resetting for efficiency, but this is
sensitive to work on the HPC that changes the state of the git environment.
E.g., at some point the git remote was set to ssh instead of https,
which caused the build not to be able to pull the most recent state of the
repo, which resulted in a period where we were overwriting the last weeks
predictions instead of appending new ones.

Delete and recloning using https is a more robust approach because it avoids
any state influencing the behavior of the pipeline.

Closes #394.

Co-authored-by: Henry Senyondo <henrykironde@gmail.com>