### PR TITLE
remove `tmp` subdirectory requirement

### DIFF
--- a/tests/testthat/test-successful_forecasts.R
+++ b/tests/testthat/test-successful_forecasts.R
@@ -5,7 +5,7 @@ context("checks that a production pipeline has been setup and run correctly")
 
 test_that("folders exist as needed",{
   fnames <- list.files()
-  expect_equal(all(c("casts", "data", "models", "raw", "tmp", "fits") %in% fnames), TRUE)
+  expect_equal(all(c("casts", "data", "models", "raw", "fits") %in% fnames), TRUE)
 })
 
 test_that("dir_config is present",{


### PR DESCRIPTION
no longer included as of portalcasting v 0.34.0
https://github.com/weecology/portalcasting/pull/267